### PR TITLE
Create migration for is_local_folder and local_path columns

### DIFF
--- a/src/db/migrations/20260424000000_alter_repos_add_local_folder.ts
+++ b/src/db/migrations/20260424000000_alter_repos_add_local_folder.ts
@@ -1,0 +1,15 @@
+import { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable("repos", (table) => {
+    table.boolean("is_local_folder").notNullable().defaultTo(false);
+    table.text("local_path").nullable();
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable("repos", (table) => {
+    table.dropColumn("is_local_folder");
+    table.dropColumn("local_path");
+  });
+}


### PR DESCRIPTION
Create a new Knex migration file at src/db/migrations/20260424000000_alter_repos_add_local_folder.ts. The up function must alter the repos table to add two columns: (1) is_local_folder boolean NOT NULL DEFAULT false; (2) local_path text nullable. The down function must drop both columns. Follow the exact same pattern as existing migration files.

## Acceptance Criteria
- [ ] File src/db/migrations/20260424000000_alter_repos_add_local_folder.ts exists
- [ ] up() adds is_local_folder boolean NOT NULL DEFAULT false
- [ ] up() adds local_path text nullable
- [ ] down() drops both columns