### PR TITLE
Refactor claudeRunner to accept a direct workDir path

### DIFF
--- a/src/services/claudeRunner.ts
+++ b/src/services/claudeRunner.ts
@@ -1,24 +1,20 @@
 import { spawn } from "child_process";
-import * as path from "path";
 import { TaskPayload } from "../interfaces";
 
 const TIMEOUT_MS = 1_800_000;
 
 export function runClaudeOnTask(options: {
-  reposPath: string;
-  owner: string;
-  repoName: string;
+  workDir: string;
   taskPayload: TaskPayload;
   anthropicApiKey?: string;
   claudePath?: string;
 }): Promise<{ success: boolean; output: string }> {
-  const { reposPath, owner, repoName, taskPayload, anthropicApiKey, claudePath } =
-    options;
+  const { workDir, taskPayload, anthropicApiKey, claudePath } = options;
 
   const env: NodeJS.ProcessEnv = { ...process.env };
   if (anthropicApiKey) env.ANTHROPIC_API_KEY = anthropicApiKey;
 
-  const localPath = path.join(reposPath, owner, repoName);
+  const localPath = workDir;
 
   const prompt = `You are an automated coding agent. You have been assigned the following task:
 

--- a/src/services/taskRunner.ts
+++ b/src/services/taskRunner.ts
@@ -1,4 +1,5 @@
 import { Knex } from "knex";
+import * as path from "path";
 import { IAppSecrets, TaskPayload } from "../interfaces";
 import { getRepoById } from "../db/repos";
 import { getTaskById, getChildTasks, updateTask, getTasksByRepoId } from "../db/tasks";
@@ -91,10 +92,12 @@ export async function runTask(
     await createTaskBranch(secrets.REPOS_PATH, repo.owner, repo.repo_name, repo.base_branch, task.id);
 
     // 9. Run Claude
+    const workDir = repo.is_local_folder
+      ? repo.local_path!
+      : path.join(secrets.REPOS_PATH, repo.owner!, repo.repo_name!);
+
     const { success, output: claudeOutput } = await runClaudeOnTask({
-      reposPath: secrets.REPOS_PATH,
-      owner: repo.owner,
-      repoName: repo.repo_name,
+      workDir,
       taskPayload,
       anthropicApiKey: secrets.ANTHROPIC_API_KEY,
       claudePath: secrets.CLAUDE_PATH,


### PR DESCRIPTION
In src/services/claudeRunner.ts, change the `runClaudeOnTask` options parameter:

- Remove the `reposPath`, `owner`, and `repoName` fields
- Add a single `workDir: string` field that is the already-resolved absolute path to the repo/folder
- Update the function body to use `workDir` directly as `localPath` instead of computing it from the three removed fields

Also update the single call site in src/services/taskRunner.ts to pass `workDir` directly. For a normal (git) repo, the value to pass is `path.join(secrets.REPOS_PATH, repo.owner!, repo.repo_name!)`. For a local folder repo, it is `repo.local_path!`. Compute it before calling `runClaudeOnTask`.

Import `path` in taskRunner.ts if it is not already imported.

## Acceptance Criteria
- [ ] runClaudeOnTask options no longer has reposPath, owner, or repoName fields
- [ ] runClaudeOnTask options has a workDir: string field
- [ ] runClaudeOnTask uses workDir as the cwd for the Claude process
- [ ] taskRunner.ts computes workDir as local_path for local folder repos and as REPOS_PATH/owner/repoName for git repos
- [ ] taskRunner.ts passes workDir to runClaudeOnTask