### PR TITLE
Update taskRunner to skip all git operations for local folder repos

### DIFF
--- a/src/db/repos.ts
+++ b/src/db/repos.ts
@@ -26,7 +26,7 @@ export async function getRepoByOwnerAndName(
 
 export async function createRepo(
   db: Knex,
-  data: { owner: string; repo_name: string; active?: boolean; base_branch?: string; require_pr?: boolean; github_token?: string | null }
+  data: { owner?: string | null; repo_name?: string | null; active?: boolean; base_branch?: string; require_pr?: boolean; github_token?: string | null; is_local_folder?: boolean; local_path?: string | null }
 ): Promise<Repo> {
   const [repo] = await db<Repo>("repos").insert(data).returning("*");
   return repo;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -24,12 +24,14 @@ export interface IDBSecrets {
 // ---- Repos table row ----
 export interface Repo {
   id: number;
-  owner: string;
-  repo_name: string;
+  owner: string | null;
+  repo_name: string | null;
   active: boolean;
   base_branch: string;
   require_pr: boolean;
   github_token: string | null;
+  is_local_folder: boolean;
+  local_path: string | null;
   created_at: Date;
 }
 

--- a/src/services/claudeRunner.ts
+++ b/src/services/claudeRunner.ts
@@ -1,24 +1,20 @@
 import { spawn } from "child_process";
-import * as path from "path";
 import { TaskPayload } from "../interfaces";
 
 const TIMEOUT_MS = 1_800_000;
 
 export function runClaudeOnTask(options: {
-  reposPath: string;
-  owner: string;
-  repoName: string;
+  workDir: string;
   taskPayload: TaskPayload;
   anthropicApiKey?: string;
   claudePath?: string;
 }): Promise<{ success: boolean; output: string }> {
-  const { reposPath, owner, repoName, taskPayload, anthropicApiKey, claudePath } =
-    options;
+  const { workDir, taskPayload, anthropicApiKey, claudePath } = options;
 
   const env: NodeJS.ProcessEnv = { ...process.env };
   if (anthropicApiKey) env.ANTHROPIC_API_KEY = anthropicApiKey;
 
-  const localPath = path.join(reposPath, owner, repoName);
+  const localPath = workDir;
 
   const prompt = `You are an automated coding agent. You have been assigned the following task:
 

--- a/src/services/taskRunner.ts
+++ b/src/services/taskRunner.ts
@@ -1,4 +1,5 @@
 import { Knex } from "knex";
+import * as path from "path";
 import { IAppSecrets, TaskPayload } from "../interfaces";
 import { getRepoById } from "../db/repos";
 import { getTaskById, getChildTasks, updateTask, getTasksByRepoId } from "../db/tasks";
@@ -85,16 +86,20 @@ export async function runTask(
   }
 
   for (let attempt = task.retry_count + 1; attempt <= MAX_ATTEMPTS; attempt++) {
-    // 8. Git setup
-    await cloneOrPull(secrets.REPOS_PATH, secrets.GH_PAT!, repo.owner, repo.repo_name);
-    await checkoutBaseBranch(secrets.REPOS_PATH, repo.owner, repo.repo_name, repo.base_branch);
-    await createTaskBranch(secrets.REPOS_PATH, repo.owner, repo.repo_name, repo.base_branch, task.id);
+    // 8. Git setup (skipped for local folder repos)
+    if (!repo.is_local_folder) {
+      await cloneOrPull(secrets.REPOS_PATH, secrets.GH_PAT!, repo.owner!, repo.repo_name!);
+      await checkoutBaseBranch(secrets.REPOS_PATH, repo.owner!, repo.repo_name!, repo.base_branch);
+      await createTaskBranch(secrets.REPOS_PATH, repo.owner!, repo.repo_name!, repo.base_branch, task.id);
+    }
 
     // 9. Run Claude
+    const workDir = repo.is_local_folder
+      ? repo.local_path!
+      : path.join(secrets.REPOS_PATH, repo.owner!, repo.repo_name!);
+
     const { success, output: claudeOutput } = await runClaudeOnTask({
-      reposPath: secrets.REPOS_PATH,
-      owner: repo.owner,
-      repoName: repo.repo_name,
+      workDir,
       taskPayload,
       anthropicApiKey: secrets.ANTHROPIC_API_KEY,
       claudePath: secrets.CLAUDE_PATH,
@@ -102,12 +107,17 @@ export async function runTask(
 
     if (success) {
       // 10. On success
-      if (await hasUncommittedChanges(secrets.REPOS_PATH, repo.owner, repo.repo_name)) {
+      if (repo.is_local_folder) {
+        await updateTask(db, task.id, { status: "done" });
+        return "success";
+      }
+
+      if (await hasUncommittedChanges(secrets.REPOS_PATH, repo.owner!, repo.repo_name!)) {
         await commitAndPushTask(
           secrets.REPOS_PATH,
           secrets.GH_PAT!,
-          repo.owner,
-          repo.repo_name,
+          repo.owner!,
+          repo.repo_name!,
           task.id,
           `feat: complete task #${task.id} - ${task.title}`
         );
@@ -122,8 +132,8 @@ export async function runTask(
 
         const pr = await createPullRequest({
           token,
-          owner: repo.owner,
-          repoName: repo.repo_name,
+          owner: repo.owner!,
+          repoName: repo.repo_name!,
           head: `task/${task.id}`,
           base: repo.base_branch,
           title: task.title,
@@ -135,8 +145,8 @@ export async function runTask(
         await mergeTaskIntoBase(
           secrets.REPOS_PATH,
           secrets.GH_PAT!,
-          repo.owner,
-          repo.repo_name,
+          repo.owner!,
+          repo.repo_name!,
           repo.base_branch,
           task.id
         );


### PR DESCRIPTION
In src/services/taskRunner.ts, update the retry loop so that when `repo.is_local_folder` is true, all git operations are skipped and task completion is simplified:

SKIP these calls when is_local_folder is true:
- cloneOrPull
- checkoutBaseBranch
- createTaskBranch
- hasUncommittedChanges
- commitAndPushTask
- mergeTaskIntoBase
- createPullRequest

When is_local_folder is true and Claude succeeds:
- Call updateTask(db, task.id, { status: 'done' }) and return 'success'

When is_local_folder is false, behavior must remain exactly as it was before.

This task depends on the claudeRunner refactor task being done first (workDir is already computed).

## Acceptance Criteria
- [ ] When repo.is_local_folder is true, cloneOrPull is not called
- [ ] When repo.is_local_folder is true, checkoutBaseBranch is not called
- [ ] When repo.is_local_folder is true, createTaskBranch is not called
- [ ] When repo.is_local_folder is true and Claude succeeds, task is marked done with no PR or merge
- [ ] When repo.is_local_folder is false, all existing git and PR logic is unchanged