### PR TITLE
Phase 2 — NewTaskDialog: create a single task from anywhere

### DIFF
--- a/src/db/tasks.ts
+++ b/src/db/tasks.ts
@@ -37,6 +37,7 @@ export async function createTask(
     order_position?: number;
     ordering_mode?: OrderingMode | null;
     model?: string | null;
+    requires_approval?: boolean;
   }
 ): Promise<Task> {
   let orderPosition = data.order_position;
@@ -67,6 +68,7 @@ export async function createTask(
       order_position: orderPosition,
       ordering_mode: data.ordering_mode ?? null,
       model: data.model ?? null,
+      requires_approval: data.requires_approval ?? false,
     })
     .returning("*");
 

--- a/src/routers/tasksRouter.ts
+++ b/src/routers/tasksRouter.ts
@@ -104,6 +104,7 @@ tasksRouter.post("/", async (req: Request, res: Response) => {
       order_position,
       ordering_mode,
       model,
+      requires_approval,
       acceptanceCriteria,
     } = req.body as {
       repo_id: number;
@@ -113,6 +114,7 @@ tasksRouter.post("/", async (req: Request, res: Response) => {
       order_position?: number;
       ordering_mode?: OrderingMode | null;
       model?: string | null;
+      requires_approval?: boolean;
       acceptanceCriteria?: string[];
     };
 
@@ -141,6 +143,7 @@ tasksRouter.post("/", async (req: Request, res: Response) => {
       order_position,
       ordering_mode,
       model,
+      requires_approval,
     });
 
     let criteria: Awaited<ReturnType<typeof createCriterion>>[] = [];

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -17,6 +17,8 @@ import type {
   RunnerImageState,
   SetupInput,
   SetupStatus,
+  TaskCreateInput,
+  TaskCreateResponse,
   TaskDetail,
   TaskEffectiveModel,
   TaskEvent,
@@ -121,6 +123,11 @@ export const reposApi = {
 export const tasksApi = {
   listByRepo: (repoId: number) =>
     apiFetch<TaskSummary[]>(`/api/tasks?repo_id=${repoId}`),
+  create: (input: TaskCreateInput) =>
+    apiFetch<TaskCreateResponse>("/api/tasks", {
+      method: "POST",
+      body: JSON.stringify(input),
+    }),
   get: (id: number) => apiFetch<TaskDetail>(`/api/tasks/${id}`),
   update: (id: number, input: TaskUpdateInput) =>
     apiFetch<TaskSummary>(`/api/tasks/${id}`, {

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -73,6 +73,32 @@ export interface TaskSummary {
   created_at: string;
 }
 
+export interface TaskCreateInput {
+  repo_id: number;
+  parent_id?: number | null;
+  title: string;
+  description?: string;
+  order_position?: number;
+  ordering_mode?: OrderingMode | null;
+  model?: string | null;
+  requires_approval?: boolean;
+  acceptanceCriteria?: string[];
+}
+
+export interface TaskCreateResponse {
+  id: number;
+  repo_id: number;
+  parent_id: number | null;
+  title: string;
+  status: TaskStatus;
+  order_position: number;
+  ordering_mode: OrderingMode | null;
+  model: string | null;
+  requires_approval: boolean;
+  created_at: string;
+  acceptanceCriteria: AcceptanceCriterion[];
+}
+
 export interface TaskUpdateInput {
   title?: string;
   description?: string;

--- a/web/src/pages/ReposPage.tsx
+++ b/web/src/pages/ReposPage.tsx
@@ -19,11 +19,12 @@ import CircularProgress from "@mui/material/CircularProgress";
 import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
 import AddIcon from "@mui/icons-material/Add";
+import AddTaskIcon from "@mui/icons-material/AddTask";
 import AccountTreeIcon from "@mui/icons-material/AccountTree";
 import SettingsIcon from "@mui/icons-material/Settings";
 import ReplayIcon from "@mui/icons-material/Replay";
 import { reposApi, tasksApi } from "../api/client";
-import type { Repo, RepoInput, TokenUsageTotals } from "../api/types";
+import type { Repo, RepoInput, TaskSummary, TokenUsageTotals } from "../api/types";
 import { useVisibilityAwarePolling } from "../hooks/useVisibilityAwarePolling";
 import RepoFormDialog from "./repos/RepoFormDialog";
 import DeleteRepoDialog from "./repos/DeleteRepoDialog";
@@ -31,6 +32,7 @@ import RepoSettingsPanel from "./repos/RepoSettingsPanel";
 import TaskTreeView from "./repos/TaskTreeView";
 import TaskDetailPage from "./repos/TaskDetailPage";
 import UsagePanel from "./repos/UsagePanel";
+import NewTaskDialog from "./tasks/NewTaskDialog";
 import {
   countTasksByStatus,
   emptyCounts,
@@ -65,6 +67,8 @@ export default function ReposPage() {
   const [selectedRepoId, setSelectedRepoId] = useState<number | null>(null);
   const [selectedTaskId, setSelectedTaskId] = useState<number | null>(null);
   const [settingsRepoId, setSettingsRepoId] = useState<number | null>(null);
+  const [newTaskOpen, setNewTaskOpen] = useState(false);
+  const [newTaskRepoId, setNewTaskRepoId] = useState<number | null>(null);
 
   const loadStatsForRepo = useCallback(
     async (repoId: number, opts?: { silent?: boolean }) => {
@@ -167,6 +171,15 @@ export default function ReposPage() {
       ),
     [repos]
   );
+
+  function openNewTask(repoId: number | null = null) {
+    setNewTaskRepoId(repoId);
+    setNewTaskOpen(true);
+  }
+
+  function handleTaskCreated(task: TaskSummary) {
+    void loadStatsForRepo(task.repo_id);
+  }
 
   function openCreate() {
     setFormMode("create");
@@ -273,13 +286,22 @@ export default function ReposPage() {
           </Typography>
         </Box>
         {repos.length > 0 && (
-          <Button
-            variant="contained"
-            startIcon={<AddIcon />}
-            onClick={openCreate}
-          >
-            Add repo
-          </Button>
+          <Stack direction="row" spacing={1}>
+            <Button
+              variant="outlined"
+              startIcon={<AddTaskIcon />}
+              onClick={() => openNewTask(null)}
+            >
+              Add task
+            </Button>
+            <Button
+              variant="contained"
+              startIcon={<AddIcon />}
+              onClick={openCreate}
+            >
+              Add repo
+            </Button>
+          </Stack>
         )}
       </Stack>
 
@@ -451,6 +473,15 @@ export default function ReposPage() {
                       </Typography>
                     </TableCell>
                     <TableCell align="right">
+                      <Tooltip title="Add task">
+                        <IconButton
+                          aria-label={`Add task to ${repoDisplayName(repo)}`}
+                          data-testid={`repo-add-task-${repo.id}`}
+                          onClick={() => openNewTask(repo.id)}
+                        >
+                          <AddTaskIcon fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
                       <IconButton
                         aria-label={`View tasks for ${repoDisplayName(repo)}`}
                         onClick={() =>
@@ -583,6 +614,14 @@ export default function ReposPage() {
         repo={deleteRepo}
         onClose={() => setDeleteRepo(null)}
         onConfirm={handleDeleteConfirm}
+      />
+      <NewTaskDialog
+        open={newTaskOpen}
+        repos={repos}
+        initialRepoId={newTaskRepoId}
+        initialParentId={null}
+        onClose={() => setNewTaskOpen(false)}
+        onCreated={handleTaskCreated}
       />
     </Box>
   );

--- a/web/src/pages/repos/TaskTreeView.tsx
+++ b/web/src/pages/repos/TaskTreeView.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import IconButton from "@mui/material/IconButton";
@@ -7,6 +8,7 @@ import Chip from "@mui/material/Chip";
 import Alert from "@mui/material/Alert";
 import CircularProgress from "@mui/material/CircularProgress";
 import Tooltip from "@mui/material/Tooltip";
+import AddIcon from "@mui/icons-material/Add";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ReplayIcon from "@mui/icons-material/Replay";
@@ -18,6 +20,7 @@ import { tasksApi } from "../../api/client";
 import type { TaskStatus, TaskSummary } from "../../api/types";
 import { useVisibilityAwarePolling } from "../../hooks/useVisibilityAwarePolling";
 import { TASK_STATUS_CHIP_COLOR } from "./repoDisplay";
+import NewTaskDialog from "../tasks/NewTaskDialog";
 
 export interface TaskNode {
   task: TaskSummary;
@@ -63,6 +66,8 @@ export default function TaskTreeView({
   const [expanded, setExpanded] = useState<Set<number>>(new Set());
   const [draggingId, setDraggingId] = useState<number | null>(null);
   const [dropTargetId, setDropTargetId] = useState<number | null>(null);
+  const [newTaskOpen, setNewTaskOpen] = useState(false);
+  const [newTaskParentId, setNewTaskParentId] = useState<number | null>(null);
 
   const load = useCallback(
     async (opts?: { silent?: boolean }) => {
@@ -264,15 +269,39 @@ export default function TaskTreeView({
 
   if (tasks.length === 0) {
     return (
-      <Typography
-        variant="body2"
-        color="text.secondary"
-        sx={{ py: 3, textAlign: "center" }}
-        role="status"
-      >
-        No tasks yet.
-      </Typography>
+      <Box sx={{ py: 3, textAlign: "center" }}>
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          role="status"
+          sx={{ mb: 2 }}
+        >
+          No tasks yet.
+        </Typography>
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          onClick={() => {
+            setNewTaskParentId(null);
+            setNewTaskOpen(true);
+          }}
+        >
+          Add task
+        </Button>
+        <NewTaskDialog
+          open={newTaskOpen}
+          initialRepoId={repoId}
+          initialParentId={newTaskParentId}
+          onClose={() => setNewTaskOpen(false)}
+          onCreated={() => void load()}
+        />
+      </Box>
     );
+  }
+
+  function openAddChild(task: TaskSummary) {
+    setNewTaskParentId(task.id);
+    setNewTaskOpen(true);
   }
 
   return (
@@ -298,6 +327,7 @@ export default function TaskTreeView({
             onAbandon={handleAbandon}
             onApprove={handleApprove}
             onViewDetail={onViewDetail}
+            onAddChild={openAddChild}
             draggingId={draggingId}
             dropTargetId={dropTargetId}
             setDraggingId={setDraggingId}
@@ -307,6 +337,13 @@ export default function TaskTreeView({
           />
         ))}
       </Stack>
+      <NewTaskDialog
+        open={newTaskOpen}
+        initialRepoId={repoId}
+        initialParentId={newTaskParentId}
+        onClose={() => setNewTaskOpen(false)}
+        onCreated={() => void load()}
+      />
     </Box>
   );
 }
@@ -320,6 +357,7 @@ interface TaskTreeNodeProps {
   onAbandon: (task: TaskSummary) => void;
   onApprove: (task: TaskSummary) => void;
   onViewDetail?: (task: TaskSummary) => void;
+  onAddChild?: (task: TaskSummary) => void;
   draggingId: number | null;
   dropTargetId: number | null;
   setDraggingId: (id: number | null) => void;
@@ -337,6 +375,7 @@ function TaskTreeNode({
   onAbandon,
   onApprove,
   onViewDetail,
+  onAddChild,
   draggingId,
   dropTargetId,
   setDraggingId,
@@ -478,6 +517,19 @@ function TaskTreeNode({
             </IconButton>
           </span>
         </Tooltip>
+        <Tooltip title="Add child task">
+          <span>
+            <IconButton
+              size="small"
+              onClick={() => onAddChild?.(task)}
+              disabled={!onAddChild}
+              aria-label={`Add child to ${task.title}`}
+              data-testid={`task-add-child-${task.id}`}
+            >
+              <AddIcon fontSize="small" />
+            </IconButton>
+          </span>
+        </Tooltip>
         <Tooltip title="View detail">
           <span>
             <IconButton
@@ -504,6 +556,7 @@ function TaskTreeNode({
               onAbandon={onAbandon}
               onApprove={onApprove}
               onViewDetail={onViewDetail}
+              onAddChild={onAddChild}
               draggingId={draggingId}
               dropTargetId={dropTargetId}
               setDraggingId={setDraggingId}

--- a/web/src/pages/tasks/NewTaskDialog.tsx
+++ b/web/src/pages/tasks/NewTaskDialog.tsx
@@ -1,0 +1,393 @@
+import { useEffect, useState } from "react";
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import CircularProgress from "@mui/material/CircularProgress";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import FormControl from "@mui/material/FormControl";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import IconButton from "@mui/material/IconButton";
+import InputLabel from "@mui/material/InputLabel";
+import MenuItem from "@mui/material/MenuItem";
+import Select from "@mui/material/Select";
+import Stack from "@mui/material/Stack";
+import Switch from "@mui/material/Switch";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import AddIcon from "@mui/icons-material/Add";
+import RemoveCircleOutlineIcon from "@mui/icons-material/RemoveCircleOutline";
+import { tasksApi } from "../../api/client";
+import type { Repo, TaskSummary } from "../../api/types";
+import { CLAUDE_MODELS } from "../../api/claudeModels";
+import { repoDisplayName } from "../repos/repoDisplay";
+
+const MODEL_INHERIT_VALUE = "__inherit__";
+
+export interface NewTaskDialogProps {
+  open: boolean;
+  /** List of repos for the repo selector. Only needed when initialRepoId is absent. */
+  repos?: Repo[];
+  /** When set, locks the dialog to this repo and hides the repo selector. */
+  initialRepoId?: number | null;
+  /** When set, pre-selects this task as the parent. null = explicit root task. */
+  initialParentId?: number | null;
+  onClose: () => void;
+  onCreated: (task: TaskSummary) => void;
+}
+
+interface FormState {
+  repoId: number | "";
+  parentId: number | null;
+  title: string;
+  description: string;
+  orderPosition: string;
+  orderingMode: "" | "sequential" | "parallel";
+  model: string;
+  requiresApproval: boolean;
+  criteria: string[];
+}
+
+function buildInitialState(
+  initialRepoId?: number | null,
+  initialParentId?: number | null
+): FormState {
+  return {
+    repoId: initialRepoId ?? "",
+    parentId: initialParentId !== undefined ? (initialParentId ?? null) : null,
+    title: "",
+    description: "",
+    orderPosition: "",
+    orderingMode: "",
+    model: MODEL_INHERIT_VALUE,
+    requiresApproval: false,
+    criteria: [],
+  };
+}
+
+export default function NewTaskDialog({
+  open,
+  repos = [],
+  initialRepoId,
+  initialParentId,
+  onClose,
+  onCreated,
+}: NewTaskDialogProps) {
+  const [form, setForm] = useState<FormState>(() =>
+    buildInitialState(initialRepoId, initialParentId)
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [parentTasks, setParentTasks] = useState<TaskSummary[]>([]);
+  const [loadingTasks, setLoadingTasks] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setForm(buildInitialState(initialRepoId, initialParentId));
+      setError(null);
+      setParentTasks([]);
+    }
+  }, [open, initialRepoId, initialParentId]);
+
+  const activeRepoId = form.repoId;
+  useEffect(() => {
+    if (!activeRepoId) {
+      setParentTasks([]);
+      return;
+    }
+    let cancelled = false;
+    setLoadingTasks(true);
+    tasksApi
+      .listByRepo(activeRepoId as number)
+      .then((tasks) => {
+        if (!cancelled) setParentTasks(tasks);
+      })
+      .catch(() => {
+        if (!cancelled) setParentTasks([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingTasks(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeRepoId]);
+
+  function update<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  }
+
+  function validate(): string | null {
+    if (!form.repoId) return "Please select a repository.";
+    if (!form.title.trim()) return "Title is required.";
+    if (
+      form.orderPosition !== "" &&
+      (!Number.isInteger(Number(form.orderPosition)) ||
+        Number(form.orderPosition) < 0)
+    ) {
+      return "Order position must be a non-negative integer.";
+    }
+    return null;
+  }
+
+  async function handleSubmit() {
+    const validationError = validate();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const raw = await tasksApi.create({
+        repo_id: form.repoId as number,
+        parent_id: form.parentId,
+        title: form.title.trim(),
+        description: form.description || undefined,
+        order_position:
+          form.orderPosition !== ""
+            ? parseInt(form.orderPosition, 10)
+            : undefined,
+        ordering_mode: form.orderingMode || null,
+        model:
+          form.model === MODEL_INHERIT_VALUE ? null : form.model || null,
+        requires_approval: form.requiresApproval,
+        acceptanceCriteria: form.criteria.filter((c) => c.trim()),
+      });
+      const summary: TaskSummary = {
+        id: raw.id,
+        repo_id: raw.repo_id,
+        parent_id: raw.parent_id,
+        title: raw.title,
+        status: raw.status,
+        order_position: raw.order_position,
+        children_count: 0,
+        requires_approval: raw.requires_approval,
+        created_at: raw.created_at,
+      };
+      onCreated(summary);
+      onClose();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to create task"
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const showRepoSelector = !initialRepoId;
+  const parentSelectValue =
+    form.parentId === null ? "null" : String(form.parentId);
+
+  return (
+    <Dialog
+      open={open}
+      onClose={submitting ? undefined : onClose}
+      maxWidth="sm"
+      fullWidth
+    >
+      <DialogTitle>New task</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          {error && <Alert severity="error">{error}</Alert>}
+
+          {showRepoSelector && (
+            <FormControl fullWidth>
+              <InputLabel id="new-task-repo-label">Repository</InputLabel>
+              <Select
+                labelId="new-task-repo-label"
+                value={form.repoId}
+                label="Repository"
+                onChange={(e) => {
+                  update("repoId", e.target.value as number | "");
+                  update("parentId", null);
+                }}
+              >
+                {repos.map((repo) => (
+                  <MenuItem key={repo.id} value={repo.id}>
+                    {repoDisplayName(repo)}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
+
+          <TextField
+            label="Title"
+            required
+            value={form.title}
+            onChange={(e) => update("title", e.target.value)}
+            fullWidth
+            autoFocus={!showRepoSelector}
+          />
+
+          <TextField
+            label="Description"
+            value={form.description}
+            onChange={(e) => update("description", e.target.value)}
+            fullWidth
+            multiline
+            minRows={3}
+          />
+
+          <FormControl fullWidth>
+            <InputLabel id="new-task-parent-label">Parent task</InputLabel>
+            <Select
+              labelId="new-task-parent-label"
+              value={parentSelectValue}
+              label="Parent task"
+              disabled={loadingTasks || !form.repoId}
+              onChange={(e) => {
+                const val = e.target.value;
+                update(
+                  "parentId",
+                  val === "null" ? null : parseInt(val, 10)
+                );
+              }}
+            >
+              <MenuItem value="null">No parent (root task)</MenuItem>
+              {parentTasks.map((t) => (
+                <MenuItem key={t.id} value={String(t.id)}>
+                  {t.title}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <TextField
+            label="Order position"
+            type="number"
+            value={form.orderPosition}
+            onChange={(e) => update("orderPosition", e.target.value)}
+            fullWidth
+            inputProps={{ min: 0 }}
+            helperText="Leave blank to append at the end"
+          />
+
+          <FormControl fullWidth>
+            <InputLabel id="new-task-ordering-label">
+              Ordering mode
+            </InputLabel>
+            <Select
+              labelId="new-task-ordering-label"
+              value={form.orderingMode}
+              label="Ordering mode"
+              onChange={(e) =>
+                update(
+                  "orderingMode",
+                  e.target.value as FormState["orderingMode"]
+                )
+              }
+            >
+              <MenuItem value="">Inherit from parent</MenuItem>
+              <MenuItem value="sequential">Sequential</MenuItem>
+              <MenuItem value="parallel">Parallel</MenuItem>
+            </Select>
+          </FormControl>
+
+          <FormControl fullWidth>
+            <InputLabel id="new-task-model-label">Model</InputLabel>
+            <Select
+              labelId="new-task-model-label"
+              value={form.model}
+              label="Model"
+              onChange={(e) => update("model", e.target.value)}
+            >
+              <MenuItem value={MODEL_INHERIT_VALUE}>
+                Inherit from parent
+              </MenuItem>
+              {CLAUDE_MODELS.map((m) => (
+                <MenuItem key={m.id} value={m.id}>
+                  {m.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <FormControlLabel
+            control={
+              <Switch
+                checked={form.requiresApproval}
+                onChange={(e) =>
+                  update("requiresApproval", e.target.checked)
+                }
+              />
+            }
+            label="Requires approval"
+          />
+
+          <Box>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+              Acceptance criteria
+            </Typography>
+            <Stack spacing={1}>
+              {form.criteria.map((criterion, i) => (
+                <Stack
+                  key={i}
+                  direction="row"
+                  alignItems="center"
+                  spacing={1}
+                >
+                  <TextField
+                    size="small"
+                    fullWidth
+                    value={criterion}
+                    onChange={(e) => {
+                      const next = [...form.criteria];
+                      next[i] = e.target.value;
+                      update("criteria", next);
+                    }}
+                    placeholder={`Criterion ${i + 1}`}
+                    inputProps={{
+                      "aria-label": `Acceptance criterion ${i + 1}`,
+                    }}
+                  />
+                  <IconButton
+                    size="small"
+                    onClick={() =>
+                      update(
+                        "criteria",
+                        form.criteria.filter((_, j) => j !== i)
+                      )
+                    }
+                    aria-label={`Remove criterion ${i + 1}`}
+                  >
+                    <RemoveCircleOutlineIcon fontSize="small" />
+                  </IconButton>
+                </Stack>
+              ))}
+              <Button
+                size="small"
+                startIcon={<AddIcon />}
+                onClick={() =>
+                  update("criteria", [...form.criteria, ""])
+                }
+                sx={{ alignSelf: "flex-start" }}
+              >
+                Add criterion
+              </Button>
+            </Stack>
+          </Box>
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => void handleSubmit()}
+          disabled={submitting}
+          startIcon={
+            submitting ? <CircularProgress size={16} /> : undefined
+          }
+        >
+          Create task
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
Add a single-task creation flow surfaced from three entry points: a top-level button on ReposPage, a per-row button on each repo, and a per-node 'Add child' button in TaskTreeView. Form covers every field POST /api/tasks accepts, including acceptance criteria.

## Acceptance Criteria
- [ ] web/src/pages/tasks/NewTaskDialog.tsx renders a MUI Dialog with: title (required), description, parent task selector (existing tasks for the repo, plus 'no parent' option), order_position (numeric, optional), ordering_mode select (sequential/parallel/inherit), ModelSelect, requires_approval Switch, AcceptanceCriteriaEditor.
- [ ] Submit POSTs to /api/tasks via tasksApi.create with the active repo_id; on 201 the dialog closes and the parent component receives the created task via onCreated callback.
- [ ] Server-side validation errors render in an Alert inside the dialog without dismissing the form state.
- [ ] ReposPage.tsx renders an 'Add task' button next to the existing 'Add repo' button (only when at least one repo exists). Clicking it opens NewTaskDialog scoped to a repo selected via a dropdown inside the dialog.
- [ ] Each row in the repos table has a new 'Add task' icon button (test id repo-add-task-<id>) that opens NewTaskDialog pre-scoped to that repo.
- [ ] TaskTreeNode renders a new 'Add child' icon button (test id task-add-child-<id>) that opens NewTaskDialog pre-scoped to that repo and pre-selecting the current node as the parent.
- [ ] Empty-state TaskTreeView ('No tasks yet') gains a primary 'Add task' CTA that opens NewTaskDialog for that repo with parent_id=null.